### PR TITLE
Expand calendar date for concurrent meetings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -77,7 +77,18 @@ export default function App() {
       <div className="flex-1 flex flex-col min-w-0">
         <TopBar user={user} />
         <main className="p-4 md:p-6">
-          <h1 className="text-2xl md:text-3xl font-semibold text-slate-800 mb-4">Parole Board – Meeting Capture</h1>
+          <div className="mb-4 flex items-center justify-between gap-3">
+            <h1 className="text-2xl md:text-3xl font-semibold text-slate-800">Parole Board – Meeting Capture</h1>
+            <button
+              onClick={handleAddMeetingClick}
+              aria-label="Add meeting"
+              aria-haspopup="dialog"
+              aria-controls="add-meeting-modal"
+              className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-3.5 py-2 rounded-md shadow-sm transition-colors"
+            >
+              <span>Add Meeting</span>
+            </button>
+          </div>
           <Calendar meetings={meetings} />
         </main>
       </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -124,7 +124,7 @@ export default function App() {
               </button>
             </div>
           </div>
-          <div className="mt-2 mb-4">
+          <div className="mt-6 mb-5 pt-2">
             <DateNav view={calendarView} currentDateISO={currentDateISO} onChange={setCurrentDateISO} />
           </div>
           <Calendar meetings={meetings} view={calendarView} currentDateISO={currentDateISO} onChangeDate={setCurrentDateISO} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,11 +3,13 @@ import Sidebar from './components/Sidebar.jsx'
 import TopBar from './components/TopBar.jsx'
 import Calendar from './components/Calendar.jsx'
 import AddMeetingModal from './components/AddMeetingModal.jsx'
+import ViewToggle from './components/ViewToggle.jsx'
 
 export default function App() {
   const [meetings, setMeetings] = useState([])
   const [showAdd, setShowAdd] = useState(false)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const [calendarView, setCalendarView] = useState('workweek')
 
   const user = { name: 'Alex Johnson', email: 'alex.johnson@example.gov.au' }
 
@@ -34,6 +36,8 @@ export default function App() {
           setMeetings(parsed)
         }
       }
+      const viewRaw = localStorage.getItem('calendarView')
+      if (viewRaw) setCalendarView(viewRaw)
     } catch {}
   }, [])
 
@@ -50,6 +54,13 @@ export default function App() {
       localStorage.setItem('meetings', JSON.stringify(meetings))
     } catch {}
   }, [meetings])
+
+  // Persist calendar view
+  useEffect(() => {
+    try {
+      localStorage.setItem('calendarView', calendarView)
+    } catch {}
+  }, [calendarView])
 
   function handleAddMeetingClick() {
     setShowAdd(true)
@@ -79,17 +90,20 @@ export default function App() {
         <main className="p-4 md:p-6">
           <div className="mb-4 flex items-center justify-between gap-3">
             <h1 className="text-2xl md:text-3xl font-semibold text-slate-800">Parole Board – Meeting Capture</h1>
-            <button
-              onClick={handleAddMeetingClick}
-              aria-label="Add meeting"
-              aria-haspopup="dialog"
-              aria-controls="add-meeting-modal"
-              className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-3.5 py-2 rounded-md shadow-sm transition-colors"
-            >
-              <span>Add Meeting</span>
-            </button>
+            <div className="flex items-center gap-2">
+              <ViewToggle value={calendarView} onChange={setCalendarView} />
+              <button
+                onClick={handleAddMeetingClick}
+                aria-label="Add meeting"
+                aria-haspopup="dialog"
+                aria-controls="add-meeting-modal"
+                className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-3.5 py-2 rounded-md shadow-sm transition-colors"
+              >
+                <span>Add Meeting</span>
+              </button>
+            </div>
           </div>
-          <Calendar meetings={meetings} />
+          <Calendar meetings={meetings} view={calendarView} />
         </main>
       </div>
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -109,10 +109,9 @@ export default function App() {
       <div className="flex-1 flex flex-col min-w-0">
         <TopBar user={user} />
         <main className="p-4 md:p-6">
-          <div className="mb-4 flex items-center justify-between gap-3">
+          <div className="flex items-center justify-between gap-3">
             <h1 className="text-2xl md:text-3xl font-semibold text-slate-800">Meeting Capture</h1>
             <div className="flex items-center gap-2">
-              <DateNav view={calendarView} currentDateISO={currentDateISO} onChange={setCurrentDateISO} />
               <ViewToggle value={calendarView} onChange={setCalendarView} />
               <button
                 onClick={handleAddMeetingClick}
@@ -124,6 +123,9 @@ export default function App() {
                 <span>Add Meeting</span>
               </button>
             </div>
+          </div>
+          <div className="mt-2 mb-4">
+            <DateNav view={calendarView} currentDateISO={currentDateISO} onChange={setCurrentDateISO} />
           </div>
           <Calendar meetings={meetings} view={calendarView} currentDateISO={currentDateISO} onChangeDate={setCurrentDateISO} />
         </main>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,11 +5,19 @@ import Calendar from './components/Calendar.jsx'
 import AddMeetingModal from './components/AddMeetingModal.jsx'
 import ViewToggle from './components/ViewToggle.jsx'
 
+function formatISO(d) {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
 export default function App() {
   const [meetings, setMeetings] = useState([])
   const [showAdd, setShowAdd] = useState(false)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const [calendarView, setCalendarView] = useState('workweek')
+  const [currentDateISO, setCurrentDateISO] = useState(formatISO(new Date()))
 
   const user = { name: 'Alex Johnson', email: 'alex.johnson@example.gov.au' }
 
@@ -26,7 +34,7 @@ export default function App() {
     } catch {}
   }, [])
 
-  // Load meetings from localStorage
+  // Load meetings and calendar prefs
   useEffect(() => {
     try {
       const raw = localStorage.getItem('meetings')
@@ -38,6 +46,8 @@ export default function App() {
       }
       const viewRaw = localStorage.getItem('calendarView')
       if (viewRaw) setCalendarView(viewRaw)
+      const dateRaw = localStorage.getItem('calendarCurrentDate')
+      if (dateRaw) setCurrentDateISO(dateRaw)
     } catch {}
   }, [])
 
@@ -55,12 +65,13 @@ export default function App() {
     } catch {}
   }, [meetings])
 
-  // Persist calendar view
+  // Persist calendar view/date
   useEffect(() => {
-    try {
-      localStorage.setItem('calendarView', calendarView)
-    } catch {}
+    try { localStorage.setItem('calendarView', calendarView) } catch {}
   }, [calendarView])
+  useEffect(() => {
+    try { localStorage.setItem('calendarCurrentDate', currentDateISO) } catch {}
+  }, [currentDateISO])
 
   function handleAddMeetingClick() {
     setShowAdd(true)
@@ -103,12 +114,12 @@ export default function App() {
               </button>
             </div>
           </div>
-          <Calendar meetings={meetings} view={calendarView} />
+          <Calendar meetings={meetings} view={calendarView} currentDateISO={currentDateISO} onChangeDate={setCurrentDateISO} />
         </main>
       </div>
 
       {showAdd && (
-        <AddMeetingModal onSave={handleSaveMeeting} onCancel={handleCancel} />
+        <AddMeetingModal onSave={handleSaveMeeting} onCancel={handleCancel} defaultDate={currentDateISO} />
       )}
     </div>
   )

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -88,7 +88,7 @@ export default function App() {
         <TopBar user={user} />
         <main className="p-4 md:p-6">
           <div className="mb-4 flex items-center justify-between gap-3">
-            <h1 className="text-2xl md:text-3xl font-semibold text-slate-800">Parole Board – Meeting Capture</h1>
+            <h1 className="text-2xl md:text-3xl font-semibold text-slate-800">Meeting Capture</h1>
             <div className="flex items-center gap-2">
               <DateNav view={calendarView} currentDateISO={currentDateISO} onChange={setCurrentDateISO} />
               <ViewToggle value={calendarView} onChange={setCalendarView} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import TopBar from './components/TopBar.jsx'
 import Calendar from './components/Calendar.jsx'
 import AddMeetingModal from './components/AddMeetingModal.jsx'
 import ViewToggle from './components/ViewToggle.jsx'
+import DateNav from './components/DateNav.jsx'
 
 function formatISO(d) {
   const y = d.getFullYear()
@@ -66,32 +67,19 @@ export default function App() {
   }, [meetings])
 
   // Persist calendar view/date
-  useEffect(() => {
-    try { localStorage.setItem('calendarView', calendarView) } catch {}
-  }, [calendarView])
-  useEffect(() => {
-    try { localStorage.setItem('calendarCurrentDate', currentDateISO) } catch {}
-  }, [currentDateISO])
+  useEffect(() => { try { localStorage.setItem('calendarView', calendarView) } catch {} }, [calendarView])
+  useEffect(() => { try { localStorage.setItem('calendarCurrentDate', currentDateISO) } catch {} }, [currentDateISO])
 
-  function handleAddMeetingClick() {
-    setShowAdd(true)
-  }
+  function handleAddMeetingClick() { setShowAdd(true) }
 
   function handleSaveMeeting(newMeeting) {
-    setMeetings((prev) => [
-      ...prev,
-      { id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`, ...newMeeting },
-    ])
+    setMeetings((prev) => [...prev, { id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`, ...newMeeting }])
     setShowAdd(false)
   }
 
-  function handleCancel() {
-    setShowAdd(false)
-  }
+  function handleCancel() { setShowAdd(false) }
 
-  function toggleSidebar() {
-    setSidebarCollapsed((v) => !v)
-  }
+  function toggleSidebar() { setSidebarCollapsed((v) => !v) }
 
   return (
     <div className="min-h-screen flex bg-gray-50">
@@ -102,6 +90,7 @@ export default function App() {
           <div className="mb-4 flex items-center justify-between gap-3">
             <h1 className="text-2xl md:text-3xl font-semibold text-slate-800">Parole Board – Meeting Capture</h1>
             <div className="flex items-center gap-2">
+              <DateNav view={calendarView} currentDateISO={currentDateISO} onChange={setCurrentDateISO} />
               <ViewToggle value={calendarView} onChange={setCalendarView} />
               <button
                 onClick={handleAddMeetingClick}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -75,7 +75,7 @@ export default function App() {
     <div className="min-h-screen flex bg-gray-50">
       <Sidebar collapsed={sidebarCollapsed} onToggleCollapse={toggleSidebar} />
       <div className="flex-1 flex flex-col min-w-0">
-        <TopBar onAddMeeting={handleAddMeetingClick} user={user} />
+        <TopBar user={user} />
         <main className="p-4 md:p-6">
           <h1 className="text-2xl md:text-3xl font-semibold text-slate-800 mb-4">Parole Board – Meeting Capture</h1>
           <Calendar meetings={meetings} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,10 +17,23 @@ export default function App() {
       const saved = localStorage.getItem('sidebarCollapsed')
       if (saved !== null) {
         setSidebarCollapsed(saved === 'true')
-        return
+      } else {
+        const prefersCollapsed = window.matchMedia('(max-width: 1024px)').matches
+        setSidebarCollapsed(prefersCollapsed)
       }
-      const prefersCollapsed = window.matchMedia('(max-width: 1024px)').matches
-      setSidebarCollapsed(prefersCollapsed)
+    } catch {}
+  }, [])
+
+  // Load meetings from localStorage
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem('meetings')
+      if (raw) {
+        const parsed = JSON.parse(raw)
+        if (Array.isArray(parsed)) {
+          setMeetings(parsed)
+        }
+      }
     } catch {}
   }, [])
 
@@ -30,6 +43,13 @@ export default function App() {
       localStorage.setItem('sidebarCollapsed', String(sidebarCollapsed))
     } catch {}
   }, [sidebarCollapsed])
+
+  // Persist meetings whenever they change
+  useEffect(() => {
+    try {
+      localStorage.setItem('meetings', JSON.stringify(meetings))
+    } catch {}
+  }, [meetings])
 
   function handleAddMeetingClick() {
     setShowAdd(true)

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -256,46 +256,48 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
           ))}
         </div>
 
-        {/* Grid body */}
-        <div className="grid" style={{ gridTemplateColumns: `${timeGutterWidthPx}px repeat(${dayList.length}, minmax(0, 1fr))` }}>
-          {/* Time gutter */}
-          <div className="relative border-r border-slate-200">
-            {slots.map((m) => (
-              <div key={m} className="border-b border-slate-100 text-[11px] text-slate-500 pr-3 flex items-start justify-end pt-1" style={{ height: `${slotHeightPx}px` }}>
-                {formatTimeLabel(m)}
-              </div>
-            ))}
-          </div>
-
-          {/* Day columns */}
-          {dayList.map((d) => {
-            // Filter meetings by ISO date if available, fallback to legacy dayIndex for Mon-Fri mapping
-            const dayMeetings = meetings.filter((mtg) => {
-              if (mtg.date) return mtg.date === d.iso
-              // legacy: map Monday-first index 0..4
-              const legacyIndex = (d.date.getDay() + 6) % 7
-              return typeof mtg.dayIndex === 'number' && mtg.dayIndex === legacyIndex
-            })
-            const { events: laidOut, overflow } = layoutMeetingsForDay(dayMeetings, d.iso, maxVisibleColumns, expandedClumpIds)
-            const isToday = d.iso === todayISO
-
-            return (
-              <div key={d.key} className="relative">
-                {slots.map((m) => (<div key={m} className="border-b border-slate-100" style={{ height: `${slotHeightPx}px` }} />))}
-                {isToday && nowTopPx >= 0 && nowTopPx <= ((endTimeMinutes - startTimeMinutes) / 30 + 1) * slotHeightPx && (
-                  <NowMarker topPx={nowTopPx} />
-                )}
-                <div className="absolute inset-x-0 top-0" style={{ height: `${((endTimeMinutes - startTimeMinutes) / 30 + 1) * slotHeightPx}px` }}>
-                  {laidOut.map((mtg) => (
-                    <MeetingBlock key={mtg.id} meeting={mtg} slotHeightPx={slotHeightPx} dayStartMinutes={startTimeMinutes} columnIndex={mtg.__layout?.columnIndex || 0} columnCount={mtg.__layout?.columnCount || 1} />
-                  ))}
-                  {overflow.map((of) => (
-                    <OverflowChip key={of.id} clumpId={of.clumpId} startMinutes={of.startMinutes} endMinutes={of.endMinutes} hiddenCount={of.hiddenCount} hiddenEvents={of.hiddenEvents} slotHeightPx={slotHeightPx} dayStartMinutes={startTimeMinutes} onToggleExpand={toggleClumpExpansion} isExpanded={expandedClumpIds.has(of.clumpId)} />
-                  ))}
+        {/* Grid body (scrollable) */}
+        <div className="max-h-[70vh] overflow-y-auto">
+          <div className="grid" style={{ gridTemplateColumns: `${timeGutterWidthPx}px repeat(${dayList.length}, minmax(0, 1fr))` }}>
+            {/* Time gutter */}
+            <div className="relative border-r border-slate-200">
+              {slots.map((m) => (
+                <div key={m} className="border-b border-slate-100 text-[11px] text-slate-500 pr-3 flex items-start justify-end pt-1" style={{ height: `${slotHeightPx}px` }}>
+                  {formatTimeLabel(m)}
                 </div>
-              </div>
-            )
-          })}
+              ))}
+            </div>
+
+            {/* Day columns */}
+            {dayList.map((d) => {
+              // Filter meetings by ISO date if available, fallback to legacy dayIndex for Mon-Fri mapping
+              const dayMeetings = meetings.filter((mtg) => {
+                if (mtg.date) return mtg.date === d.iso
+                // legacy: map Monday-first index 0..4
+                const legacyIndex = (d.date.getDay() + 6) % 7
+                return typeof mtg.dayIndex === 'number' && mtg.dayIndex === legacyIndex
+              })
+              const { events: laidOut, overflow } = layoutMeetingsForDay(dayMeetings, d.iso, maxVisibleColumns, expandedClumpIds)
+              const isToday = d.iso === todayISO
+
+              return (
+                <div key={d.key} className="relative">
+                  {slots.map((m) => (<div key={m} className="border-b border-slate-100" style={{ height: `${slotHeightPx}px` }} />))}
+                  {isToday && nowTopPx >= 0 && nowTopPx <= ((endTimeMinutes - startTimeMinutes) / 30 + 1) * slotHeightPx && (
+                    <NowMarker topPx={nowTopPx} />
+                  )}
+                  <div className="absolute inset-x-0 top-0" style={{ height: `${((endTimeMinutes - startTimeMinutes) / 30 + 1) * slotHeightPx}px` }}>
+                    {laidOut.map((mtg) => (
+                      <MeetingBlock key={mtg.id} meeting={mtg} slotHeightPx={slotHeightPx} dayStartMinutes={startTimeMinutes} columnIndex={mtg.__layout?.columnIndex || 0} columnCount={mtg.__layout?.columnCount || 1} />
+                    ))}
+                    {overflow.map((of) => (
+                      <OverflowChip key={of.id} clumpId={of.clumpId} startMinutes={of.startMinutes} endMinutes={of.endMinutes} hiddenCount={of.hiddenCount} hiddenEvents={of.hiddenEvents} slotHeightPx={slotHeightPx} dayStartMinutes={startTimeMinutes} onToggleExpand={toggleClumpExpansion} isExpanded={expandedClumpIds.has(of.clumpId)} />
+                    ))}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -195,7 +195,10 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
               const iso = toISODate(d)
               const inMonth = d.getMonth() === currentMonth
               const isToday = iso === todayISO
-              const count = meetings.filter((m) => m.date ? m.date === iso : false).length
+              const dayMeetings = meetings.filter((m) => m.date ? m.date === iso : false).sort((a, b) => a.startMinutes - b.startMinutes)
+              const count = dayMeetings.length
+              const visible = dayMeetings.slice(0, 2)
+              const overflow = count - visible.length
               return (
                 <button
                   key={iso}
@@ -204,6 +207,18 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
                   className={`relative aspect-[4/3] rounded-md border text-left ${inMonth ? 'bg-white border-slate-200' : 'bg-slate-50 border-slate-200/70'} ${isToday ? 'ring-2 ring-red-400' : ''}`}
                 >
                   <div className="absolute top-1 left-2 text-[11px] font-medium text-slate-600">{d.getDate()}</div>
+                  <div className="absolute inset-x-1 top-5 bottom-1 overflow-hidden">
+                    <div className="space-y-0.5">
+                      {visible.map((m) => (
+                        <div key={m.id} className="truncate text-[11px] px-1 py-0.5 rounded bg-slate-100 text-slate-700">
+                          <span className="font-medium">{formatTimeLabel(m.startMinutes)}</span> {m.title}
+                        </div>
+                      ))}
+                      {overflow > 0 && (
+                        <div className="text-[11px] text-slate-500">+{overflow} more</div>
+                      )}
+                    </div>
+                  </div>
                   {count > 0 && (
                     <div className="absolute bottom-1 right-1 text-[11px] px-1.5 py-0.5 rounded-full bg-blue-600 text-white">{count}</div>
                   )}

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -253,7 +253,7 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
         </div>
 
         {/* Grid body (scrollable) */}
-        <div className="overflow-y-auto" style={{ maxHeight: 'calc(100vh - 260px)' }}>
+        <div className="h-[65vh] overflow-y-auto">
           <div className="grid" style={{ gridTemplateColumns: `${timeGutterWidthPx}px repeat(${dayList.length}, minmax(0, 1fr))` }}>
             {/* Time gutter */}
             <div className="relative border-r border-slate-200">

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -219,7 +219,7 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
                   onClick={() => onChangeDate?.(iso)}
                   className={`relative aspect-[4/3] rounded-md border text-left ${inMonth ? 'bg-white border-slate-200' : 'bg-slate-50 border-slate-200/70'} ${isToday ? 'ring-2 ring-red-400' : ''}`}
                 >
-                  <div className="absolute top-1 left-2 text-[11px] font-medium text-slate-600">{d.getDate()}</div>
+                  <div className="absolute top-1 left-1 right-1 text-center text-[11px] font-medium text-slate-600">{d.getDate()}</div>
                   <div className="absolute inset-x-1 top-5 bottom-1 overflow-auto">
                     <div className="space-y-0.5 pr-1">
                       {dayMeetings.map((m) => (
@@ -250,7 +250,7 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
         <div className="grid" style={{ gridTemplateColumns: `${timeGutterWidthPx}px repeat(${dayList.length}, minmax(0, 1fr))` }}>
           <div className="h-14 border-b border-r border-slate-200 bg-slate-50/60" />
           {dayList.map((d) => (
-            <div key={d.key} className="h-14 border-b border-slate-200 bg-slate-50/60 flex items-end px-3 pb-2 text-sm font-medium text-slate-700">
+            <div key={d.key} className="h-14 border-b border-slate-200 bg-slate-50/60 flex items-end justify-center px-3 pb-2 text-sm font-medium text-slate-700">
               {d.label}
             </div>
           ))}

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -227,9 +227,7 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
                           <span className="font-medium">{formatTimeLabel(m.startMinutes)}</span> {m.title}
                         </div>
                       ))}
-                      {count === 0 && (
-                        <div className="text-[11px] text-slate-400 italic px-1">No meetings</div>
-                      )}
+
                     </div>
                   </div>
                   {count > 0 && (

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -13,6 +13,7 @@ const days = [
 const slotHeightPx = 48
 const startTimeMinutes = 8 * 60 // 8:00 AM
 const endTimeMinutes = 16 * 60 + 30 // 4:30 PM
+const timeGutterWidthPx = 112
 
 function generateTimeSlots() {
   const slots = []
@@ -162,8 +163,8 @@ export default function Calendar({ meetings = [] }) {
     <div className="w-full overflow-x-auto">
       <div className="min-w-[960px] rounded-lg border border-slate-200 bg-white shadow-sm">
         {/* Day headers */}
-        <div className="grid" style={{ gridTemplateColumns: '96px repeat(5, minmax(0, 1fr))' }}>
-          <div className="h-14 border-b border-slate-200 bg-slate-50/60" />
+        <div className="grid" style={{ gridTemplateColumns: `${timeGutterWidthPx}px repeat(5, minmax(0, 1fr))` }}>
+          <div className="h-14 border-b border-r border-slate-200 bg-slate-50/60" />
           {days.map((d) => (
             <div key={d.key} className="h-14 border-b border-slate-200 bg-slate-50/60 flex items-end px-3 pb-2 text-sm font-medium text-slate-700">
               {d.label}
@@ -172,13 +173,13 @@ export default function Calendar({ meetings = [] }) {
         </div>
 
         {/* Grid body */}
-        <div className="grid" style={{ gridTemplateColumns: '96px repeat(5, minmax(0, 1fr))' }}>
+        <div className="grid" style={{ gridTemplateColumns: `${timeGutterWidthPx}px repeat(5, minmax(0, 1fr))` }}>
           {/* Time gutter */}
-          <div className="relative">
+          <div className="relative border-r border-slate-200">
             {slots.map((m) => (
               <div
                 key={m}
-                className="border-b border-slate-100 text-[11px] text-slate-500 pr-2 flex items-start justify-end pt-1"
+                className="border-b border-slate-100 text-[11px] text-slate-500 pr-3 flex items-start justify-end pt-1"
                 style={{ height: `${slotHeightPx}px` }}
               >
                 {formatTimeLabel(m)}

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -1,15 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import MeetingBlock from './MeetingBlock.jsx'
 import OverflowChip from './OverflowChip.jsx'
 import NowMarker from './NowMarker.jsx'
-
-const baseDays = [
-  { key: 'mon', label: 'Mon 04/08' },
-  { key: 'tue', label: 'Tue 05/08' },
-  { key: 'wed', label: 'Wed 06/08' },
-  { key: 'thu', label: 'Thu 07/08' },
-  { key: 'fri', label: 'Fri 08/08' },
-]
 
 const slotHeightPx = 48
 const startTimeMinutes = 8 * 60 // 8:00 AM
@@ -18,9 +10,7 @@ const timeGutterWidthPx = 112
 
 function generateTimeSlots() {
   const slots = []
-  for (let m = startTimeMinutes; m <= endTimeMinutes; m += 30) {
-    slots.push(m)
-  }
+  for (let m = startTimeMinutes; m <= endTimeMinutes; m += 30) slots.push(m)
   return slots
 }
 
@@ -33,14 +23,52 @@ function formatTimeLabel(totalMinutes) {
   return `${hour12}:${minutes.toString().padStart(2, '0')}${period}`
 }
 
-function getTodayIndex() {
-  const jsDay = new Date().getDay() // 0=Sun
-  const mondayFirstIndex = (jsDay + 6) % 7 // 0=Mon..6=Sun
-  return mondayFirstIndex >= 0 && mondayFirstIndex <= 4 ? mondayFirstIndex : -1
+function isoToday() {
+  const d = new Date()
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
 }
 
 function getMinutesSinceMidnight(date = new Date()) {
   return date.getHours() * 60 + date.getMinutes()
+}
+
+function startOfWeekMonday(date) {
+  const d = new Date(date)
+  const day = d.getDay() // 0 Sun .. 6 Sat
+  const diff = (day + 6) % 7 // 0 Mon .. 6 Sun
+  d.setDate(d.getDate() - diff)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+function startOfMonth(date) {
+  const d = new Date(date)
+  d.setDate(1)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+function addDays(date, num) {
+  const d = new Date(date)
+  d.setDate(d.getDate() + num)
+  return d
+}
+
+function toISODate(date) {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+function formatDayHeader(date) {
+  const dow = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'][(date.getDay() + 6) % 7]
+  const mm = String(date.getMonth() + 1).padStart(2, '0')
+  const dd = String(date.getDate()).padStart(2, '0')
+  return `${dow} ${dd}/${mm}`
 }
 
 function useMaxVisibleColumns() {
@@ -61,7 +89,7 @@ function useMaxVisibleColumns() {
   return maxCols
 }
 
-function layoutMeetingsForDay(dayMeetings, dayIndex, maxVisibleColumns = 5, expandedClumpIds = new Set()) {
+function layoutMeetingsForDay(dayMeetings, dayKey, maxVisibleColumns = 5, expandedClumpIds = new Set()) {
   if (!dayMeetings || dayMeetings.length === 0) return { events: [], overflow: [] }
   const sorted = [...dayMeetings].sort((a, b) => {
     if (a.startMinutes !== b.startMinutes) return a.startMinutes - b.startMinutes
@@ -90,21 +118,17 @@ function layoutMeetingsForDay(dayMeetings, dayIndex, maxVisibleColumns = 5, expa
       eventColumnIndex.set(evt, placedColumn)
       maxConcurrent = Math.max(maxConcurrent, columnEndTimes.length)
     }
-    const clumpId = `clump-${dayIndex}-${clumpStartMin}-${clumpEndMin}`
+    const clumpId = `clump-${dayKey}-${clumpStartMin}-${clumpEndMin}`
     const isExpanded = expandedClumpIds.has(clumpId)
     const visibleColumns = isExpanded ? (maxConcurrent || 1) : Math.min(maxConcurrent || 1, maxVisibleColumns)
     for (const evt of clump) {
       const colIdx = eventColumnIndex.get(evt) || 0
-      if (colIdx < visibleColumns) {
-        laidOut.push({ ...evt, __layout: { columnIndex: colIdx, columnCount: visibleColumns } })
-      }
+      if (colIdx < visibleColumns) laidOut.push({ ...evt, __layout: { columnIndex: colIdx, columnCount: visibleColumns } })
     }
     if (!isExpanded) {
       const hiddenEvents = clump.filter((evt) => (eventColumnIndex.get(evt) || 0) >= visibleColumns)
       const hiddenCount = hiddenEvents.length
-      if (hiddenCount > 0) {
-        overflowChips.push({ id: `overflow-${dayIndex}-${clumpStartMin}-${clumpEndMin}`, clumpId, startMinutes: clumpStartMin, endMinutes: clumpEndMin, hiddenCount, hiddenEvents })
-      }
+      if (hiddenCount > 0) overflowChips.push({ id: `overflow-${dayKey}-${clumpStartMin}-${clumpEndMin}`, clumpId, startMinutes: clumpStartMin, endMinutes: clumpEndMin, hiddenCount, hiddenEvents })
     }
   }
   for (let i = 1; i < sorted.length; i++) {
@@ -116,7 +140,7 @@ function layoutMeetingsForDay(dayMeetings, dayIndex, maxVisibleColumns = 5, expa
   return { events: laidOut, overflow: overflowChips }
 }
 
-export default function Calendar({ meetings = [], view = 'workweek' }) {
+export default function Calendar({ meetings = [], view = 'workweek', currentDateISO, onChangeDate }) {
   const slots = generateTimeSlots()
   const maxVisibleColumns = useMaxVisibleColumns()
   const [expandedClumpIds, setExpandedClumpIds] = useState(new Set())
@@ -125,51 +149,81 @@ export default function Calendar({ meetings = [], view = 'workweek' }) {
     setExpandedClumpIds((prev) => { const next = new Set(prev); if (next.has(clumpId)) next.delete(clumpId); else next.add(clumpId); return next })
   }
 
-  // Now marker
-  const todayIndex = getTodayIndex()
+  // Dates for the active view
+  const todayISO = isoToday()
+  const baseDate = useMemo(() => (currentDateISO ? new Date(currentDateISO + 'T00:00:00') : new Date()), [currentDateISO])
+
+  const dayList = useMemo(() => {
+    if (view === 'day') {
+      const d = baseDate
+      return [{ date: d, iso: toISODate(d), key: toISODate(d), label: formatDayHeader(d) }]
+    }
+    if (view === 'week') {
+      const start = startOfWeekMonday(baseDate)
+      return Array.from({ length: 7 }, (_, i) => {
+        const d = addDays(start, i)
+        return { date: d, iso: toISODate(d), key: toISODate(d), label: formatDayHeader(d) }
+      })
+    }
+    // workweek default
+    const start = startOfWeekMonday(baseDate)
+    return Array.from({ length: 5 }, (_, i) => {
+      const d = addDays(start, i)
+      return { date: d, iso: toISODate(d), key: toISODate(d), label: formatDayHeader(d) }
+    })
+  }, [view, baseDate])
+
+  // Now marker position (used in time-based views)
   const [nowTopPx, setNowTopPx] = useState(() => ((getMinutesSinceMidnight() - startTimeMinutes) / 30) * slotHeightPx)
   useEffect(() => { const i = setInterval(() => setNowTopPx(((getMinutesSinceMidnight() - startTimeMinutes) / 30) * slotHeightPx), 30000); return () => clearInterval(i) }, [])
 
-  // Determine days based on view
-  let days
-  if (view === 'day') {
-    const ti = todayIndex >= 0 ? todayIndex : 0
-    days = [baseDays[ti]]
-  } else if (view === 'week') {
-    // Simple week: prepend Sat/Sun labels for demo
-    days = [
-      { key: 'sat', label: 'Sat 03/08' },
-      ...baseDays,
-      { key: 'sun', label: 'Sun 09/08' },
-    ]
-  } else if (view === 'month') {
-    // Placeholder month grid: 4 rows x 7 cols
+  // Month grid computation
+  if (view === 'month') {
+    const startMonth = startOfMonth(baseDate)
+    const weekStart = startOfWeekMonday(startMonth)
+    const days = Array.from({ length: 42 }, (_, i) => addDays(weekStart, i))
+    const currentMonth = baseDate.getMonth()
+
     return (
       <div className="w-full overflow-x-auto">
         <div className="min-w-[960px] rounded-lg border border-slate-200 bg-white shadow-sm p-4">
-          <div className="flex items-center justify-between mb-3">
-            <div className="text-lg font-semibold text-slate-800">Month view (placeholder)</div>
+          <div className="grid grid-cols-7 text-xs font-medium text-slate-500 px-1 mb-2">
+            {['Mon','Tue','Wed','Thu','Fri','Sat','Sun'].map((d) => (<div key={d} className="px-2 py-1">{d}</div>))}
           </div>
-          <div className="grid grid-cols-7 gap-3">
-            {Array.from({ length: 28 }).map((_, i) => (
-              <div key={i} className="aspect-[4/3] border border-slate-200 rounded-md bg-slate-50" />
-            ))}
+          <div className="grid grid-cols-7 gap-2">
+            {days.map((d, idx) => {
+              const iso = toISODate(d)
+              const inMonth = d.getMonth() === currentMonth
+              const isToday = iso === todayISO
+              const count = meetings.filter((m) => m.date ? m.date === iso : false).length
+              return (
+                <button
+                  key={iso}
+                  type="button"
+                  onClick={() => onChangeDate?.(iso)}
+                  className={`relative aspect-[4/3] rounded-md border text-left ${inMonth ? 'bg-white border-slate-200' : 'bg-slate-50 border-slate-200/70'} ${isToday ? 'ring-2 ring-red-400' : ''}`}
+                >
+                  <div className="absolute top-1 left-2 text-[11px] font-medium text-slate-600">{d.getDate()}</div>
+                  {count > 0 && (
+                    <div className="absolute bottom-1 right-1 text-[11px] px-1.5 py-0.5 rounded-full bg-blue-600 text-white">{count}</div>
+                  )}
+                </button>
+              )
+            })}
           </div>
         </div>
       </div>
     )
-  } else {
-    // workweek
-    days = baseDays
   }
 
+  // Time-based views (day/workweek/week)
   return (
     <div className="w-full overflow-x-auto">
       <div className="min-w-[960px] rounded-lg border border-slate-200 bg-white shadow-sm">
         {/* Day headers */}
-        <div className="grid" style={{ gridTemplateColumns: `${timeGutterWidthPx}px repeat(${days.length}, minmax(0, 1fr))` }}>
+        <div className="grid" style={{ gridTemplateColumns: `${timeGutterWidthPx}px repeat(${dayList.length}, minmax(0, 1fr))` }}>
           <div className="h-14 border-b border-r border-slate-200 bg-slate-50/60" />
-          {days.map((d) => (
+          {dayList.map((d) => (
             <div key={d.key} className="h-14 border-b border-slate-200 bg-slate-50/60 flex items-end px-3 pb-2 text-sm font-medium text-slate-700">
               {d.label}
             </div>
@@ -177,7 +231,7 @@ export default function Calendar({ meetings = [], view = 'workweek' }) {
         </div>
 
         {/* Grid body */}
-        <div className="grid" style={{ gridTemplateColumns: `${timeGutterWidthPx}px repeat(${days.length}, minmax(0, 1fr))` }}>
+        <div className="grid" style={{ gridTemplateColumns: `${timeGutterWidthPx}px repeat(${dayList.length}, minmax(0, 1fr))` }}>
           {/* Time gutter */}
           <div className="relative border-r border-slate-200">
             {slots.map((m) => (
@@ -188,15 +242,21 @@ export default function Calendar({ meetings = [], view = 'workweek' }) {
           </div>
 
           {/* Day columns */}
-          {days.map((d, dayIndex) => {
-            const realDayIndex = view === 'week' ? Math.max(0, Math.min(dayIndex - 1, 4)) : dayIndex // map Sat/Sun to edges
-            const dayMeetings = meetings.filter((mtg) => mtg.dayIndex === realDayIndex)
-            const { events: laidOut, overflow } = layoutMeetingsForDay(dayMeetings, realDayIndex, maxVisibleColumns, expandedClumpIds)
+          {dayList.map((d) => {
+            // Filter meetings by ISO date if available, fallback to legacy dayIndex for Mon-Fri mapping
+            const dayMeetings = meetings.filter((mtg) => {
+              if (mtg.date) return mtg.date === d.iso
+              // legacy: map Monday-first index 0..4
+              const legacyIndex = (d.date.getDay() + 6) % 7
+              return typeof mtg.dayIndex === 'number' && mtg.dayIndex === legacyIndex
+            })
+            const { events: laidOut, overflow } = layoutMeetingsForDay(dayMeetings, d.iso, maxVisibleColumns, expandedClumpIds)
+            const isToday = d.iso === todayISO
 
             return (
               <div key={d.key} className="relative">
                 {slots.map((m) => (<div key={m} className="border-b border-slate-100" style={{ height: `${slotHeightPx}px` }} />))}
-                {view !== 'month' && todayIndex === realDayIndex && nowTopPx >= 0 && nowTopPx <= ((endTimeMinutes - startTimeMinutes) / 30 + 1) * slotHeightPx && (
+                {isToday && nowTopPx >= 0 && nowTopPx <= ((endTimeMinutes - startTimeMinutes) / 30 + 1) * slotHeightPx && (
                   <NowMarker topPx={nowTopPx} />
                 )}
                 <div className="absolute inset-x-0 top-0" style={{ height: `${((endTimeMinutes - startTimeMinutes) / 30 + 1) * slotHeightPx}px` }}>

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -140,6 +140,19 @@ function layoutMeetingsForDay(dayMeetings, dayKey, maxVisibleColumns = 5, expand
   return { events: laidOut, overflow: overflowChips }
 }
 
+function getMonthPillClass(type) {
+  switch (type) {
+    case 'General':
+      return 'bg-blue-50 text-blue-800 border border-blue-200'
+    case 'Suspensions':
+      return 'bg-pink-50 text-pink-800 border border-pink-200'
+    case 'Reviews':
+      return 'bg-emerald-50 text-emerald-800 border border-emerald-200'
+    default:
+      return 'bg-slate-100 text-slate-700 border border-slate-200'
+  }
+}
+
 export default function Calendar({ meetings = [], view = 'workweek', currentDateISO, onChangeDate }) {
   const slots = generateTimeSlots()
   const maxVisibleColumns = useMaxVisibleColumns()
@@ -210,7 +223,7 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
                   <div className="absolute inset-x-1 top-5 bottom-1 overflow-auto">
                     <div className="space-y-0.5 pr-1">
                       {dayMeetings.map((m) => (
-                        <div key={m.id} className="truncate text-[11px] px-1 py-0.5 rounded bg-slate-100 text-slate-700">
+                        <div key={m.id} className={`${getMonthPillClass(m.type)} truncate text-[11px] px-1 py-0.5 rounded`}>
                           <span className="font-medium">{formatTimeLabel(m.startMinutes)}</span> {m.title}
                         </div>
                       ))}

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -257,7 +257,7 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
         </div>
 
         {/* Grid body (scrollable) */}
-        <div className="max-h-[70vh] overflow-y-auto">
+        <div className="overflow-y-auto" style={{ maxHeight: 'calc(100vh - 260px)' }}>
           <div className="grid" style={{ gridTemplateColumns: `${timeGutterWidthPx}px repeat(${dayList.length}, minmax(0, 1fr))` }}>
             {/* Time gutter */}
             <div className="relative border-r border-slate-200">

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -201,7 +201,7 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
       <div className="w-full overflow-x-auto">
         <div className="min-w-[960px] rounded-lg border border-slate-200 bg-white shadow-sm p-4">
           <div className="grid grid-cols-7 text-xs font-medium text-slate-500 px-1 mb-2">
-            {['Mon','Tue','Wed','Thu','Fri','Sat','Sun'].map((d) => (<div key={d} className="px-2 py-1">{d}</div>))}
+            {['Mon','Tue','Wed','Thu','Fri','Sat','Sun'].map((d) => (<div key={d} className="px-2 py-1 text-center">{d}</div>))}
           </div>
           <div className="grid grid-cols-7 gap-2">
             {days.map((d, idx) => {

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -195,10 +195,10 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
               const iso = toISODate(d)
               const inMonth = d.getMonth() === currentMonth
               const isToday = iso === todayISO
-              const dayMeetings = meetings.filter((m) => m.date ? m.date === iso : false).sort((a, b) => a.startMinutes - b.startMinutes)
+              const dayMeetings = meetings
+                .filter((m) => (m.date ? m.date === iso : false))
+                .sort((a, b) => a.startMinutes - b.startMinutes)
               const count = dayMeetings.length
-              const visible = dayMeetings.slice(0, 2)
-              const overflow = count - visible.length
               return (
                 <button
                   key={iso}
@@ -207,15 +207,15 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
                   className={`relative aspect-[4/3] rounded-md border text-left ${inMonth ? 'bg-white border-slate-200' : 'bg-slate-50 border-slate-200/70'} ${isToday ? 'ring-2 ring-red-400' : ''}`}
                 >
                   <div className="absolute top-1 left-2 text-[11px] font-medium text-slate-600">{d.getDate()}</div>
-                  <div className="absolute inset-x-1 top-5 bottom-1 overflow-hidden">
-                    <div className="space-y-0.5">
-                      {visible.map((m) => (
+                  <div className="absolute inset-x-1 top-5 bottom-1 overflow-auto">
+                    <div className="space-y-0.5 pr-1">
+                      {dayMeetings.map((m) => (
                         <div key={m.id} className="truncate text-[11px] px-1 py-0.5 rounded bg-slate-100 text-slate-700">
                           <span className="font-medium">{formatTimeLabel(m.startMinutes)}</span> {m.title}
                         </div>
                       ))}
-                      {overflow > 0 && (
-                        <div className="text-[11px] text-slate-500">+{overflow} more</div>
+                      {count === 0 && (
+                        <div className="text-[11px] text-slate-400 italic px-1">No meetings</div>
                       )}
                     </div>
                   </div>

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -120,7 +120,7 @@ function layoutMeetingsForDay(dayMeetings, dayKey, maxVisibleColumns = 5, expand
     }
     const clumpId = `clump-${dayKey}-${clumpStartMin}-${clumpEndMin}`
     const isExpanded = expandedClumpIds.has(clumpId)
-    const visibleColumns = isExpanded ? (maxConcurrent || 1) : Math.min(maxConcurrent || 1, maxVisibleColumns)
+    const visibleColumns = maxConcurrent || 1
     for (const evt of clump) {
       const colIdx = eventColumnIndex.get(evt) || 0
       if (colIdx < visibleColumns) laidOut.push({ ...evt, __layout: { columnIndex: colIdx, columnCount: visibleColumns } })

--- a/src/components/DateNav.jsx
+++ b/src/components/DateNav.jsx
@@ -91,6 +91,9 @@ export default function DateNav({ view, currentDateISO, onChange }) {
         <button type="button" onClick={goPrev} className="px-2 py-1.5 text-slate-700 hover:bg-slate-50" aria-label="Previous">
           <ChevronLeft className="h-4 w-4" />
         </button>
+        <button type="button" onClick={goToday} className="px-2.5 py-1.5 text-sm text-slate-700 hover:bg-slate-50 border-x border-slate-300" aria-label="Jump to today">
+          Today
+        </button>
         <div className="px-3 py-1.5 text-sm font-medium text-slate-800 min-w-[12ch] text-center">
           {label}
         </div>
@@ -98,9 +101,6 @@ export default function DateNav({ view, currentDateISO, onChange }) {
           <ChevronRight className="h-4 w-4" />
         </button>
       </div>
-      <button type="button" onClick={goToday} className="px-2.5 py-1.5 text-sm rounded-md border border-slate-300 bg-white hover:bg-slate-50 text-slate-700 shadow-sm">
-        Today
-      </button>
     </div>
   )
 }

--- a/src/components/DateNav.jsx
+++ b/src/components/DateNav.jsx
@@ -1,0 +1,106 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
+function parseISOToDate(iso) {
+  return new Date(iso + 'T00:00:00')
+}
+
+function toISO(date) {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+function isoToday() {
+  const d = new Date()
+  return toISO(d)
+}
+
+function startOfWeekMonday(date) {
+  const d = new Date(date)
+  const day = d.getDay()
+  const diff = (day + 6) % 7
+  d.setDate(d.getDate() - diff)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+function addDays(date, n) {
+  const d = new Date(date)
+  d.setDate(d.getDate() + n)
+  return d
+}
+
+function addMonths(date, n) {
+  const d = new Date(date)
+  d.setDate(1)
+  d.setMonth(d.getMonth() + n)
+  return d
+}
+
+function formatLabel(view, iso) {
+  const d = parseISOToDate(iso)
+  const months = ['January','February','March','April','May','June','July','August','September','October','November','December']
+  const dows = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat']
+
+  if (view === 'day') {
+    return `${dows[d.getDay()]}, ${String(d.getDate()).padStart(2,'0')} ${months[d.getMonth()].slice(0,3)} ${d.getFullYear()}`
+  }
+  if (view === 'month') {
+    return `${months[d.getMonth()]} ${d.getFullYear()}`
+  }
+  // week or workweek: show range Mon..Sun/Mon..Fri
+  const start = startOfWeekMonday(d)
+  const length = view === 'week' ? 7 : 5
+  const end = addDays(start, length - 1)
+  const sameMonth = start.getMonth() === end.getMonth()
+  if (sameMonth) {
+    return `${months[start.getMonth()]} ${start.getDate()}–${end.getDate()}, ${end.getFullYear()}`
+  }
+  return `${months[start.getMonth()]} ${start.getDate()} – ${months[end.getMonth()]} ${end.getDate()}, ${end.getFullYear()}`
+}
+
+export default function DateNav({ view, currentDateISO, onChange }) {
+  const label = formatLabel(view, currentDateISO)
+
+  function goPrev() {
+    const d = parseISOToDate(currentDateISO)
+    let next
+    if (view === 'day') next = addDays(d, -1)
+    else if (view === 'week' || view === 'workweek') next = addDays(d, -7)
+    else next = addMonths(d, -1)
+    onChange?.(toISO(next))
+  }
+
+  function goNext() {
+    const d = parseISOToDate(currentDateISO)
+    let next
+    if (view === 'day') next = addDays(d, 1)
+    else if (view === 'week' || view === 'workweek') next = addDays(d, 7)
+    else next = addMonths(d, 1)
+    onChange?.(toISO(next))
+  }
+
+  function goToday() {
+    onChange?.(isoToday())
+  }
+
+  return (
+    <div className="inline-flex items-center gap-2">
+      <div className="inline-flex rounded-md border border-slate-300 bg-white shadow-sm overflow-hidden">
+        <button type="button" onClick={goPrev} className="px-2 py-1.5 text-slate-700 hover:bg-slate-50" aria-label="Previous">
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+        <div className="px-3 py-1.5 text-sm font-medium text-slate-800 min-w-[12ch] text-center">
+          {label}
+        </div>
+        <button type="button" onClick={goNext} className="px-2 py-1.5 text-slate-700 hover:bg-slate-50" aria-label="Next">
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+      <button type="button" onClick={goToday} className="px-2.5 py-1.5 text-sm rounded-md border border-slate-300 bg-white hover:bg-slate-50 text-slate-700 shadow-sm">
+        Today
+      </button>
+    </div>
+  )
+}

--- a/src/components/DateNav.jsx
+++ b/src/components/DateNav.jsx
@@ -49,7 +49,6 @@ function formatLabel(view, iso) {
   if (view === 'month') {
     return `${months[d.getMonth()]} ${d.getFullYear()}`
   }
-  // week or workweek: show range Mon..Sun/Mon..Fri
   const start = startOfWeekMonday(d)
   const length = view === 'week' ? 7 : 5
   const end = addDays(start, length - 1)
@@ -87,12 +86,12 @@ export default function DateNav({ view, currentDateISO, onChange }) {
 
   return (
     <div className="inline-flex items-center gap-2">
+      <button type="button" onClick={goToday} className="px-2.5 py-1.5 text-sm rounded-md border border-slate-300 bg-white hover:bg-slate-50 text-slate-700 shadow-sm" aria-label="Jump to today">
+        Today
+      </button>
       <div className="inline-flex rounded-md border border-slate-300 bg-white shadow-sm overflow-hidden">
         <button type="button" onClick={goPrev} className="px-2 py-1.5 text-slate-700 hover:bg-slate-50" aria-label="Previous">
           <ChevronLeft className="h-4 w-4" />
-        </button>
-        <button type="button" onClick={goToday} className="px-2.5 py-1.5 text-sm text-slate-700 hover:bg-slate-50 border-x border-slate-300" aria-label="Jump to today">
-          Today
         </button>
         <div className="px-3 py-1.5 text-sm font-medium text-slate-800 min-w-[12ch] text-center">
           {label}

--- a/src/components/MeetingBlock.jsx
+++ b/src/components/MeetingBlock.jsx
@@ -5,16 +5,22 @@ const typeToColor = {
   Default: 'bg-slate-500/90 hover:bg-slate-500',
 }
 
-export default function MeetingBlock({ meeting, slotHeightPx, dayStartMinutes }) {
+export default function MeetingBlock({ meeting, slotHeightPx, dayStartMinutes, columnIndex = 0, columnCount = 1 }) {
   const top = ((meeting.startMinutes - dayStartMinutes) / 30) * slotHeightPx
   const height = ((meeting.endMinutes - meeting.startMinutes) / 30) * slotHeightPx
 
   const color = typeToColor[meeting.type] || typeToColor.Default
 
+  // Side-by-side layout: compute percentage width and left offset with small gap
+  const gapPct = 2 // percent gap between columns
+  const totalGapPct = gapPct * (columnCount - 1)
+  const widthPct = columnCount > 0 ? (100 - totalGapPct) / columnCount : 100
+  const leftPct = columnIndex * (widthPct + gapPct)
+
   return (
     <div
-      className={`${color} absolute left-1 right-1 rounded-md shadow-sm text-white p-2.5 transition-colors`}
-      style={{ top: `${top}px`, height: `${height}px` }}
+      className={`${color} absolute rounded-md shadow-sm text-white p-2.5 transition-colors`}
+      style={{ top: `${top}px`, height: `${height}px`, left: `${leftPct}%`, width: `${widthPct}%` }}
     >
       <div className="text-[11px] font-medium opacity-90">
         {format12Hour(meeting.startMinutes)} – {format12Hour(meeting.endMinutes)}

--- a/src/components/NowMarker.jsx
+++ b/src/components/NowMarker.jsx
@@ -1,0 +1,15 @@
+export default function NowMarker({ topPx, showLabel = true, label = 'Now' }) {
+  return (
+    <div className="absolute inset-x-0 z-20 pointer-events-none" style={{ top: `${topPx}px` }}>
+      <div className="relative">
+        <div className="absolute -left-1.5 top-[-3px] h-2.5 w-2.5 rounded-full bg-red-600" />
+        <div className="border-t-2 border-red-500" />
+        {showLabel && (
+          <div className="absolute -top-3 left-2 text-[10px] font-medium text-red-600 bg-white/80 px-1 rounded">
+            {label}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/OverflowChip.jsx
+++ b/src/components/OverflowChip.jsx
@@ -1,0 +1,46 @@
+import { useState } from 'react'
+
+export default function OverflowChip({ startMinutes, endMinutes, hiddenCount, hiddenEvents = [], slotHeightPx, dayStartMinutes }) {
+  const top = ((startMinutes - dayStartMinutes) / 30) * slotHeightPx
+  const height = ((endMinutes - startMinutes) / 30) * slotHeightPx
+
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="absolute left-0 right-0" style={{ top: `${top}px`, height: `${height}px` }}>
+      <div className="absolute right-1 bottom-1">
+        <button
+          type="button"
+          className="px-1.5 py-0.5 text-[11px] rounded bg-slate-800/80 text-white hover:bg-slate-800"
+          onClick={() => setOpen((v) => !v)}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          aria-label={`${hiddenCount} more overlapping meetings`}
+        >
+          +{hiddenCount} more
+        </button>
+        {open && (
+          <div className="absolute z-10 mt-1 w-64 max-h-64 overflow-auto rounded-md border border-slate-200 bg-white shadow-lg p-2">
+            <div className="text-xs text-slate-500 mb-1">Overlapping meetings</div>
+            <ul className="space-y-1">
+              {hiddenEvents.map((ev) => (
+                <li key={ev.id} className="text-sm">
+                  <span className="font-medium">{format12Hour(ev.startMinutes)}–{format12Hour(ev.endMinutes)}</span> {ev.title}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function format12Hour(total) {
+  const hours24 = Math.floor(total / 60)
+  const minutes = total % 60
+  const period = hours24 >= 12 ? 'PM' : 'AM'
+  let hour12 = hours24 % 12
+  if (hour12 === 0) hour12 = 12
+  return `${hour12}:${minutes.toString().padStart(2, '0')}${period}`
+}

--- a/src/components/OverflowChip.jsx
+++ b/src/components/OverflowChip.jsx
@@ -1,17 +1,39 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
-export default function OverflowChip({ startMinutes, endMinutes, hiddenCount, hiddenEvents = [], slotHeightPx, dayStartMinutes }) {
+export default function OverflowChip({ clumpId, startMinutes, endMinutes, hiddenCount, hiddenEvents = [], slotHeightPx, dayStartMinutes, onToggleExpand, isExpanded }) {
   const top = ((startMinutes - dayStartMinutes) / 30) * slotHeightPx
   const height = ((endMinutes - startMinutes) / 30) * slotHeightPx
 
   const [open, setOpen] = useState(false)
+  const popoverRef = useRef(null)
+
+  useEffect(() => {
+    function onKey(e) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    function onClick(e) {
+      if (popoverRef.current && !popoverRef.current.contains(e.target)) setOpen(false)
+    }
+    if (open) {
+      document.addEventListener('keydown', onKey)
+      document.addEventListener('mousedown', onClick)
+      return () => {
+        document.removeEventListener('keydown', onKey)
+        document.removeEventListener('mousedown', onClick)
+      }
+    }
+  }, [open])
+
+  const isMobile = typeof window !== 'undefined' && window.innerWidth < 640
 
   return (
     <div className="absolute left-0 right-0" style={{ top: `${top}px`, height: `${height}px` }}>
+      {/* subtle highlight of overlapped range when open */}
+      {open && <div className="absolute inset-0 rounded-sm bg-blue-500/5 pointer-events-none" />}
       <div className="absolute right-1 bottom-1">
         <button
           type="button"
-          className="px-1.5 py-0.5 text-[11px] rounded bg-slate-800/80 text-white hover:bg-slate-800"
+          className="px-1.5 py-0.5 text-[11px] rounded bg-slate-800/80 text-white hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
           onClick={() => setOpen((v) => !v)}
           aria-haspopup="dialog"
           aria-expanded={open}
@@ -20,8 +42,29 @@ export default function OverflowChip({ startMinutes, endMinutes, hiddenCount, hi
           +{hiddenCount} more
         </button>
         {open && (
-          <div className="absolute z-10 mt-1 w-64 max-h-64 overflow-auto rounded-md border border-slate-200 bg-white shadow-lg p-2">
-            <div className="text-xs text-slate-500 mb-1">Overlapping meetings</div>
+          <div
+            ref={popoverRef}
+            className={
+              isMobile
+                ? 'fixed inset-x-0 bottom-0 z-50 max-h-[60vh] rounded-t-lg border border-slate-200 bg-white shadow-lg p-3'
+                : 'absolute z-50 mt-1 w-72 max-h-64 overflow-auto rounded-md border border-slate-200 bg-white shadow-lg p-2 right-0'
+            }
+            role="dialog"
+            aria-label="Overlapping meetings"
+          >
+            <div className="flex items-center justify-between mb-2">
+              <div className="text-xs text-slate-500">Overlapping meetings</div>
+              <button
+                className="text-xs text-blue-600 hover:underline"
+                type="button"
+                onClick={() => {
+                  onToggleExpand?.(clumpId)
+                  setOpen(false)
+                }}
+              >
+                {isExpanded ? 'Collapse' : 'Show all side-by-side'}
+              </button>
+            </div>
             <ul className="space-y-1">
               {hiddenEvents.map((ev) => (
                 <li key={ev.id} className="text-sm">

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,4 +1,5 @@
 import { Home, Search, Clock, FilePlus2, FileText, CalendarDays, ClipboardList, CalendarCheck2, Users2, ListTodo, BarChart2, Settings, HelpCircle, ChevronLeft, ChevronRight } from 'lucide-react'
+import { useEffect, useState } from 'react'
 
 const menuItems = [
   { label: 'Home', icon: Home },
@@ -6,9 +7,14 @@ const menuItems = [
   { label: 'Recent Matters', icon: Clock },
   { label: 'New Applications', icon: FilePlus2 },
   { label: 'New Matter', icon: FileText },
-  { label: 'Board Meetings', icon: CalendarDays },
-  { label: 'Meeting Capture', icon: ClipboardList, active: true },
-  { label: 'Scheduling', icon: CalendarCheck2 },
+  {
+    label: 'Board Meetings',
+    icon: CalendarDays,
+    children: [
+      { label: 'Meeting Capture', icon: ClipboardList, active: true },
+      { label: 'Scheduling', icon: CalendarCheck2 },
+    ],
+  },
   { label: 'Parties', icon: Users2 },
   { label: 'Actions', icon: ListTodo },
   { label: 'Reports', icon: BarChart2 },
@@ -18,6 +24,29 @@ const menuItems = [
 
 export default function Sidebar({ collapsed = false, onToggleCollapse }) {
   const widthClass = collapsed ? 'md:w-16' : 'md:w-64 lg:w-72 xl:w-80'
+  const [boardOpen, setBoardOpen] = useState(false)
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem('sidebar.boardOpen')
+      if (raw !== null) setBoardOpen(raw === 'true')
+    } catch {}
+  }, [])
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('sidebar.boardOpen', String(boardOpen))
+    } catch {}
+  }, [boardOpen])
+
+  function handleBoardClick() {
+    if (collapsed) {
+      onToggleCollapse?.()
+      setTimeout(() => setBoardOpen(true), 0)
+    } else {
+      setBoardOpen((v) => !v)
+    }
+  }
 
   return (
     <aside className={`hidden md:flex ${widthClass} flex-col bg-slate-900 text-slate-100 min-h-screen`}>
@@ -47,20 +76,58 @@ export default function Sidebar({ collapsed = false, onToggleCollapse }) {
       </div>
       <nav className="flex-1 overflow-y-auto py-4">
         <ul className="space-y-1 px-2">
-          {menuItems.map(({ label, icon: Icon, active }) => (
+          {menuItems.map(({ label, icon: Icon, active, children }) => (
             <li key={label}>
-              <a
-                href="#"
-                title={label}
-                className={`group flex items-center ${collapsed ? 'justify-center px-2' : 'gap-3 px-3'} py-2.5 rounded-md transition-colors ${
-                  active
-                    ? 'bg-slate-800 text-white'
-                    : 'text-slate-300 hover:bg-slate-800/70 hover:text-white'
-                }`}
-              >
-                <Icon className="h-5 w-5 opacity-90" />
-                {!collapsed && <span className="text-sm font-medium">{label}</span>}
-              </a>
+              {children ? (
+                <button
+                  type="button"
+                  onClick={handleBoardClick}
+                  className={`w-full group flex items-center ${collapsed ? 'justify-center px-2' : 'gap-3 px-3'} py-2.5 rounded-md transition-colors text-left ${
+                    boardOpen ? 'bg-slate-800 text-white' : 'text-slate-300 hover:bg-slate-800/70 hover:text-white'
+                  }`}
+                  aria-expanded={boardOpen}
+                  aria-controls="board-meetings-submenu"
+                >
+                  <Icon className="h-5 w-5 opacity-90" />
+                  {!collapsed && (
+                    <>
+                      <span className="text-sm font-medium flex-1">{label}</span>
+                      <ChevronRight className={`h-4 w-4 transition-transform ${boardOpen ? 'rotate-90' : ''}`} />
+                    </>
+                  )}
+                </button>
+              ) : (
+                <a
+                  href="#"
+                  title={label}
+                  className={`group flex items-center ${collapsed ? 'justify-center px-2' : 'gap-3 px-3'} py-2.5 rounded-md transition-colors ${
+                    active ? 'bg-slate-800 text-white' : 'text-slate-300 hover:bg-slate-800/70 hover:text-white'
+                  }`}
+                >
+                  <Icon className="h-5 w-5 opacity-90" />
+                  {!collapsed && <span className="text-sm font-medium">{label}</span>}
+                </a>
+              )}
+
+              {/* Submenu */}
+              {children && !collapsed && boardOpen && (
+                <ul id="board-meetings-submenu" className="mt-1 space-y-1">
+                  {children.map(({ label: subLabel, icon: SubIcon, active: subActive }) => (
+                    <li key={subLabel}>
+                      <a
+                        href="#"
+                        title={subLabel}
+                        className={`group flex items-center gap-3 pl-11 pr-3 py-2 rounded-md transition-colors ${
+                          subActive ? 'bg-slate-800 text-white' : 'text-slate-300 hover:bg-slate-800/70 hover:text-white'
+                        }`}
+                      >
+                        <SubIcon className="h-4 w-4 opacity-90" />
+                        <span className="text-sm">{subLabel}</span>
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              )}
             </li>
           ))}
         </ul>

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -10,7 +10,7 @@ function getInitials(name = '') {
     .join('') || 'U'
 }
 
-export default function TopBar({ onAddMeeting, user }) {
+export default function TopBar({ user }) {
   const initials = getInitials(user?.name)
 
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false)
@@ -61,15 +61,6 @@ export default function TopBar({ onAddMeeting, user }) {
         </button>
 
         <div className="ml-auto flex items-center gap-3 md:gap-4">
-          <button
-            onClick={onAddMeeting}
-            aria-label="Add meeting"
-            aria-haspopup="dialog"
-            aria-controls="add-meeting-modal"
-            className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-3.5 py-2 rounded-md shadow-sm transition-colors"
-          >
-            <span>Add Meeting</span>
-          </button>
 
           <div className="hidden sm:flex items-center gap-3">
             <div

--- a/src/components/ViewToggle.jsx
+++ b/src/components/ViewToggle.jsx
@@ -1,0 +1,27 @@
+export default function ViewToggle({ value, onChange }) {
+  const options = [
+    { key: 'day', label: 'Day' },
+    { key: 'workweek', label: 'Work Week' },
+    { key: 'week', label: 'Week' },
+    { key: 'month', label: 'Month' },
+  ]
+
+  return (
+    <div className="inline-flex items-center rounded-md border border-slate-300 bg-white shadow-sm overflow-hidden">
+      {options.map((opt, idx) => {
+        const isActive = value === opt.key
+        return (
+          <button
+            key={opt.key}
+            type="button"
+            onClick={() => onChange?.(opt.key)}
+            className={`px-2.5 py-1.5 text-sm ${isActive ? 'bg-slate-900 text-white' : 'text-slate-700 hover:bg-slate-50'} ${idx !== options.length - 1 ? 'border-r border-slate-300' : ''}`}
+            aria-pressed={isActive}
+          >
+            {opt.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}


### PR DESCRIPTION
Implement side-by-side rendering for overlapping calendar meetings to improve readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b6ff3c7-220c-4034-9b91-780e928c62e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7b6ff3c7-220c-4034-9b91-780e928c62e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

