### PR TITLE
Horizontal scroll week view for busy schedules

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -111,21 +111,21 @@ export default function App() {
         <main className="p-4 md:p-6">
           <div className="flex items-center justify-between gap-3">
             <h1 className="text-2xl md:text-3xl font-semibold text-slate-800">Meeting Capture</h1>
-            <div className="flex items-center gap-2">
-              <ViewToggle value={calendarView} onChange={setCalendarView} />
-              <button
-                onClick={handleAddMeetingClick}
-                aria-label="Add meeting"
-                aria-haspopup="dialog"
-                aria-controls="add-meeting-modal"
-                className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-3.5 py-2 rounded-md shadow-sm transition-colors"
-              >
-                <span>Add Meeting</span>
-              </button>
-            </div>
+            <button
+              onClick={handleAddMeetingClick}
+              aria-label="Add meeting"
+              aria-haspopup="dialog"
+              aria-controls="add-meeting-modal"
+              className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-3.5 py-2 rounded-md shadow-sm transition-colors"
+            >
+              <span>Add Meeting</span>
+            </button>
           </div>
           <div className="mt-6 mb-5 pt-2">
-            <DateNav view={calendarView} currentDateISO={currentDateISO} onChange={setCurrentDateISO} />
+            <div className="flex items-center justify-between gap-3">
+              <DateNav view={calendarView} currentDateISO={currentDateISO} onChange={setCurrentDateISO} />
+              <div className="flex-shrink-0"><ViewToggle value={calendarView} onChange={setCalendarView} /></div>
+            </div>
           </div>
           <Calendar meetings={meetings} view={calendarView} currentDateISO={currentDateISO} onChangeDate={setCurrentDateISO} />
         </main>

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -320,7 +320,11 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
                       if (el) {
                         dayScrollRefs.set(d.key, el)
                         // Defer to next tick to ensure sizes are measured
-                        queueMicrotask(() => updateScrollHints(d.key))
+                        if (typeof queueMicrotask === 'function') {
+                          queueMicrotask(() => updateScrollHints(d.key))
+                        } else {
+                          Promise.resolve().then(() => updateScrollHints(d.key))
+                        }
                       } else {
                         dayScrollRefs.delete(d.key)
                         setScrollHints((prev) => {

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -246,11 +246,23 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
         {/* Day headers */}
         <div className="grid" style={{ gridTemplateColumns: `${timeGutterWidthPx}px repeat(${dayList.length}, minmax(0, 1fr))` }}>
           <div className="h-14 border-b border-r border-slate-200 bg-slate-50/60" />
-          {dayList.map((d) => (
-            <div key={d.key} className="h-14 border-b border-slate-200 bg-slate-50/60 flex items-end justify-center px-3 pb-2 text-sm font-medium text-slate-700">
-              {d.label}
-            </div>
-          ))}
+          {dayList.map((d) => {
+            const dayCount = meetings.filter((mtg) => {
+              if (mtg.date) return mtg.date === d.iso
+              const legacyIndex = (d.date.getDay() + 6) % 7
+              return typeof mtg.dayIndex === 'number' && mtg.dayIndex === legacyIndex
+            }).length
+            return (
+              <div key={d.key} className="h-14 border-b border-slate-200 bg-slate-50/60 flex items-end justify-center px-3 pb-2 text-sm font-medium text-slate-700">
+                <div className="flex items-center gap-2">
+                  <span>{d.label}</span>
+                  {dayCount > 0 && (
+                    <span className="text-[11px] px-1.5 py-0.5 rounded-full bg-blue-600 text-white">{dayCount}</span>
+                  )}
+                </div>
+              </div>
+            )
+          })}
         </div>
 
         {/* Grid body (scrollable) */}

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -247,23 +247,11 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
         {/* Day headers */}
         <div className="grid" style={{ gridTemplateColumns: `${timeGutterWidthPx}px repeat(${dayList.length}, minmax(0, 1fr))` }}>
           <div className="h-14 border-b border-r border-slate-200 bg-slate-50/60" />
-          {dayList.map((d) => {
-            const dayCount = meetings.filter((mtg) => {
-              if (mtg.date) return mtg.date === d.iso
-              const legacyIndex = (d.date.getDay() + 6) % 7
-              return typeof mtg.dayIndex === 'number' && mtg.dayIndex === legacyIndex
-            }).length
-            return (
-              <div key={d.key} className="h-14 border-b border-slate-200 bg-slate-50/60 flex items-end justify-center px-3 pb-2 text-sm font-medium text-slate-700">
-                <div className="flex items-center gap-2">
-                  <span>{d.label}</span>
-                  {dayCount > 0 && (
-                    <span className="text-[11px] px-1.5 py-0.5 rounded-full bg-blue-600 text-white">{dayCount}</span>
-                  )}
-                </div>
-              </div>
-            )
-          })}
+          {dayList.map((d) => (
+            <div key={d.key} className="h-14 border-b border-slate-200 bg-slate-50/60 flex items-end justify-center px-3 pb-2 text-sm font-medium text-slate-700">
+              {d.label}
+            </div>
+          ))}
         </div>
 
         {/* Grid body (scrollable) */}

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import MeetingBlock from './MeetingBlock.jsx'
 
 import NowMarker from './NowMarker.jsx'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
+
 
 const slotHeightPx = 48
 const startTimeMinutes = 8 * 60 // 8:00 AM
@@ -155,20 +155,6 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
   const slots = generateTimeSlots()
   const maxVisibleColumns = useMaxVisibleColumns()
   const [expandedClumpIds, setExpandedClumpIds] = useState(new Set())
-  const dayScrollRefs = useState(() => new Map())[0]
-  const [scrollHints, setScrollHints] = useState({})
-
-  function updateScrollHints(dayKey) {
-    const el = dayScrollRefs.get(dayKey)
-    if (!el) return
-    const canLeft = el.scrollLeft > 0
-    const canRight = el.scrollLeft + el.clientWidth < el.scrollWidth - 1
-    setScrollHints((prev) => {
-      const prevForDay = prev[dayKey] || {}
-      if (prevForDay.canLeft === canLeft && prevForDay.canRight === canRight) return prev
-      return { ...prev, [dayKey]: { canLeft, canRight } }
-    })
-  }
 
   function toggleClumpExpansion(clumpId) {
     setExpandedClumpIds((prev) => { const next = new Set(prev); if (next.has(clumpId)) next.delete(clumpId); else next.add(clumpId); return next })
@@ -313,62 +299,13 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
                     <NowMarker topPx={nowTopPx} />
                   )}
                   {/* Horizontal overflow container for overlapping meetings */}
-                  <div
-                    className="absolute inset-x-0 top-0 overflow-x-auto scrollbar-thin"
-                    style={{ height: `${gridHeightPx}px` }}
-                    ref={(el) => {
-                      if (el) {
-                        dayScrollRefs.set(d.key, el)
-                        // Defer to next tick to ensure sizes are measured
-                        if (typeof queueMicrotask === 'function') {
-                          queueMicrotask(() => updateScrollHints(d.key))
-                        } else {
-                          Promise.resolve().then(() => updateScrollHints(d.key))
-                        }
-                      } else {
-                        dayScrollRefs.delete(d.key)
-                        setScrollHints((prev) => {
-                          const { [d.key]: _omit, ...rest } = prev
-                          return rest
-                        })
-                      }
-                    }}
-                    onScroll={() => updateScrollHints(d.key)}
-                  >
+                  <div className="absolute inset-x-0 top-0 overflow-x-auto" style={{ height: `${gridHeightPx}px` }}>
                     <div className="relative" style={{ width: `${widthScale * 100}%`, height: `${gridHeightPx}px` }}>
                       {laidOut.map((mtg) => (
                         <MeetingBlock key={mtg.id} meeting={mtg} slotHeightPx={slotHeightPx} dayStartMinutes={startTimeMinutes} columnIndex={mtg.__layout?.columnIndex || 0} columnCount={mtg.__layout?.columnCount || 1} />
                       ))}
                     </div>
                   </div>
-                  {/* Scroll hint gradients */}
-                  {widthScale > 1 && scrollHints[d.key]?.canLeft && (
-                    <div className="pointer-events-none absolute inset-y-0 left-0 w-6 bg-gradient-to-r from-white to-transparent" />
-                  )}
-                  {widthScale > 1 && scrollHints[d.key]?.canRight && (
-                    <div className="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-white to-transparent" />
-                  )}
-                  {/* Arrow nudge buttons */}
-                  {widthScale > 1 && scrollHints[d.key]?.canLeft && (
-                    <button
-                      type="button"
-                      className="absolute left-1 top-1/2 -translate-y-1/2 z-20 h-6 w-6 rounded-full bg-slate-800/70 text-white flex items-center justify-center hover:bg-slate-800"
-                      onClick={() => dayScrollRefs.get(d.key)?.scrollBy({ left: -160, behavior: 'smooth' })}
-                      aria-label="Scroll left"
-                    >
-                      <ChevronLeft className="h-4 w-4" />
-                    </button>
-                  )}
-                  {widthScale > 1 && scrollHints[d.key]?.canRight && (
-                    <button
-                      type="button"
-                      className="absolute right-1 top-1/2 -translate-y-1/2 z-20 h-6 w-6 rounded-full bg-slate-800/70 text-white flex items-center justify-center hover:bg-slate-800"
-                      onClick={() => dayScrollRefs.get(d.key)?.scrollBy({ left: 160, behavior: 'smooth' })}
-                      aria-label="Scroll right"
-                    >
-                      <ChevronRight className="h-4 w-4" />
-                    </button>
-                  )}
                 </div>
               )
             })}

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -90,7 +90,7 @@ function useMaxVisibleColumns() {
   return maxCols
 }
 
-function layoutMeetingsForDay(dayMeetings, dayKey, maxVisibleColumns = 5, expandedClumpIds = new Set()) {
+function layoutMeetingsForDay(dayMeetings, dayKey) {
   if (!dayMeetings || dayMeetings.length === 0) return { events: [], maxConcurrent: 0 }
   const sorted = [...dayMeetings].sort((a, b) => {
     if (a.startMinutes !== b.startMinutes) return a.startMinutes - b.startMinutes
@@ -119,10 +119,6 @@ function layoutMeetingsForDay(dayMeetings, dayKey, maxVisibleColumns = 5, expand
       eventColumnIndex.set(evt, placedColumn)
       maxConcurrent = Math.max(maxConcurrent, columnEndTimes.length)
     }
-    const clumpId = `clump-${dayKey}-${clumpStartMin}-${clumpEndMin}`
-    const isExpanded = expandedClumpIds.has(clumpId)
-    // We always compute against total columns so we can horizontally scroll to see more
-    // All events get their absolute left/width based on the total columns for the clump
     for (const evt of clump) {
       const colIdx = eventColumnIndex.get(evt) || 0
       laidOut.push({ ...evt, __layout: { columnIndex: colIdx, columnCount: maxConcurrent } })
@@ -154,11 +150,6 @@ function getMonthPillClass(type) {
 export default function Calendar({ meetings = [], view = 'workweek', currentDateISO, onChangeDate }) {
   const slots = generateTimeSlots()
   const maxVisibleColumns = useMaxVisibleColumns()
-  const [expandedClumpIds, setExpandedClumpIds] = useState(new Set())
-
-  function toggleClumpExpansion(clumpId) {
-    setExpandedClumpIds((prev) => { const next = new Set(prev); if (next.has(clumpId)) next.delete(clumpId); else next.add(clumpId); return next })
-  }
 
   // Dates for the active view
   const todayISO = isoToday()
@@ -275,7 +266,7 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
                 const legacyIndex = (d.date.getDay() + 6) % 7
                 return typeof mtg.dayIndex === 'number' && mtg.dayIndex === legacyIndex
               })
-              const { events: laidOut, maxConcurrent } = layoutMeetingsForDay(dayMeetings, d.iso, maxVisibleColumns, expandedClumpIds)
+              const { events: laidOut, maxConcurrent } = layoutMeetingsForDay(dayMeetings, d.iso)
               const isToday = d.iso === todayISO
               const gridHeightPx = ((endTimeMinutes - startTimeMinutes) / 30 + 1) * slotHeightPx
               const widthScale = Math.max(1, (maxConcurrent || 1) / (maxVisibleColumns || 1))

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import MeetingBlock from './MeetingBlock.jsx'
 
 import NowMarker from './NowMarker.jsx'
@@ -156,11 +156,11 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
   const slots = generateTimeSlots()
   const maxVisibleColumns = useMaxVisibleColumns()
   const [expandedClumpIds, setExpandedClumpIds] = useState(new Set())
-  const dayScrollRefs = useState(() => new Map())[0]
+  const dayScrollRefs = useRef({})
   const [scrollHints, setScrollHints] = useState({})
 
   function updateScrollHints(dayKey) {
-    const el = dayScrollRefs.get(dayKey)
+    const el = dayScrollRefs.current[dayKey]
     if (!el) return
     const canLeft = el.scrollLeft > 0
     const canRight = el.scrollLeft + el.clientWidth < el.scrollWidth - 1
@@ -308,10 +308,10 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
                     style={{ height: `${gridHeightPx}px` }}
                     ref={(el) => {
                       if (el) {
-                        dayScrollRefs.set(d.key, el)
+                        dayScrollRefs.current[d.key] = el
                         setTimeout(() => updateScrollHints(d.key), 0)
                       } else {
-                        dayScrollRefs.delete(d.key)
+                        delete dayScrollRefs.current[d.key]
                         setScrollHints((prev) => {
                           const { [d.key]: _omit, ...rest } = prev
                           return rest
@@ -344,7 +344,7 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
                     <button
                       type="button"
                       className="hidden sm:flex absolute left-1 top-1/2 -translate-y-1/2 z-20 h-6 w-6 rounded-full bg-slate-800/70 text-white items-center justify-center hover:bg-slate-800"
-                      onClick={() => dayScrollRefs.get(d.key)?.scrollBy({ left: -160, behavior: 'smooth' })}
+                      onClick={() => dayScrollRefs.current[d.key]?.scrollBy({ left: -160, behavior: 'smooth' })}
                       aria-label="Scroll left"
                     >
                       <ChevronLeft className="h-4 w-4" />
@@ -354,7 +354,7 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
                     <button
                       type="button"
                       className="hidden sm:flex absolute right-1 top-1/2 -translate-y-1/2 z-20 h-6 w-6 rounded-full bg-slate-800/70 text-white items-center justify-center hover:bg-slate-800"
-                      onClick={() => dayScrollRefs.get(d.key)?.scrollBy({ left: 160, behavior: 'smooth' })}
+                      onClick={() => dayScrollRefs.current[d.key]?.scrollBy({ left: 160, behavior: 'smooth' })}
                       aria-label="Scroll right"
                     >
                       <ChevronRight className="h-4 w-4" />

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -309,8 +309,7 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
                     ref={(el) => {
                       if (el) {
                         dayScrollRefs.set(d.key, el)
-                        if (typeof queueMicrotask === 'function') queueMicrotask(() => updateScrollHints(d.key))
-                        else Promise.resolve().then(() => updateScrollHints(d.key))
+                        setTimeout(() => updateScrollHints(d.key), 0)
                       } else {
                         dayScrollRefs.delete(d.key)
                         setScrollHints((prev) => {

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -279,19 +279,19 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
                     <NowMarker topPx={nowTopPx} />
                   )}
                   {/* Horizontal overflow container for overlapping meetings */}
-                  <div className="absolute inset-x-0 top-0 overflow-x-auto" style={{ height: `${gridHeightPx}px` }}>
+                  <div className="absolute inset-x-0 top-0 overflow-x-auto relative" style={{ height: `${gridHeightPx}px` }}>
                     <div className="relative" style={{ width: `${widthScale * 100}%`, height: `${gridHeightPx}px` }}>
                       {laidOut.map((mtg) => (
                         <MeetingBlock key={mtg.id} meeting={mtg} slotHeightPx={slotHeightPx} dayStartMinutes={startTimeMinutes} columnIndex={mtg.__layout?.columnIndex || 0} columnCount={mtg.__layout?.columnCount || 1} />
                       ))}
                     </div>
+                    {/* +N more pill (shown when overflow exists) */}
+                    {extraCols > 0 && (
+                      <div className="absolute right-1.5 top-1.5 z-20">
+                        <span className="text-[11px] px-1.5 py-0.5 rounded-full bg-slate-800/80 text-white">+{extraCols} more</span>
+                      </div>
+                    )}
                   </div>
-                  {/* +N more pill (shown when overflow exists) */}
-                  {extraCols > 0 && (
-                    <div className="absolute right-1.5 top-1.5 z-20">
-                      <span className="text-[11px] px-1.5 py-0.5 rounded-full bg-slate-800/80 text-white">+{extraCols} more</span>
-                    </div>
-                  )}
                 </div>
               )
             })}

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import MeetingBlock from './MeetingBlock.jsx'
 
 import NowMarker from './NowMarker.jsx'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 
 const slotHeightPx = 48
 const startTimeMinutes = 8 * 60 // 8:00 AM
@@ -154,6 +155,20 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
   const slots = generateTimeSlots()
   const maxVisibleColumns = useMaxVisibleColumns()
   const [expandedClumpIds, setExpandedClumpIds] = useState(new Set())
+  const dayScrollRefs = useState(() => new Map())[0]
+  const [scrollHints, setScrollHints] = useState({})
+
+  function updateScrollHints(dayKey) {
+    const el = dayScrollRefs.get(dayKey)
+    if (!el) return
+    const canLeft = el.scrollLeft > 0
+    const canRight = el.scrollLeft + el.clientWidth < el.scrollWidth - 1
+    setScrollHints((prev) => {
+      const prevForDay = prev[dayKey] || {}
+      if (prevForDay.canLeft === canLeft && prevForDay.canRight === canRight) return prev
+      return { ...prev, [dayKey]: { canLeft, canRight } }
+    })
+  }
 
   function toggleClumpExpansion(clumpId) {
     setExpandedClumpIds((prev) => { const next = new Set(prev); if (next.has(clumpId)) next.delete(clumpId); else next.add(clumpId); return next })
@@ -298,13 +313,58 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
                     <NowMarker topPx={nowTopPx} />
                   )}
                   {/* Horizontal overflow container for overlapping meetings */}
-                  <div className="absolute inset-x-0 top-0 overflow-x-auto" style={{ height: `${gridHeightPx}px` }}>
+                  <div
+                    className="absolute inset-x-0 top-0 overflow-x-auto scrollbar-thin"
+                    style={{ height: `${gridHeightPx}px` }}
+                    ref={(el) => {
+                      if (el) {
+                        dayScrollRefs.set(d.key, el)
+                        // Defer to next tick to ensure sizes are measured
+                        queueMicrotask(() => updateScrollHints(d.key))
+                      } else {
+                        dayScrollRefs.delete(d.key)
+                        setScrollHints((prev) => {
+                          const { [d.key]: _omit, ...rest } = prev
+                          return rest
+                        })
+                      }
+                    }}
+                    onScroll={() => updateScrollHints(d.key)}
+                  >
                     <div className="relative" style={{ width: `${widthScale * 100}%`, height: `${gridHeightPx}px` }}>
                       {laidOut.map((mtg) => (
                         <MeetingBlock key={mtg.id} meeting={mtg} slotHeightPx={slotHeightPx} dayStartMinutes={startTimeMinutes} columnIndex={mtg.__layout?.columnIndex || 0} columnCount={mtg.__layout?.columnCount || 1} />
                       ))}
                     </div>
                   </div>
+                  {/* Scroll hint gradients */}
+                  {widthScale > 1 && scrollHints[d.key]?.canLeft && (
+                    <div className="pointer-events-none absolute inset-y-0 left-0 w-6 bg-gradient-to-r from-white to-transparent" />
+                  )}
+                  {widthScale > 1 && scrollHints[d.key]?.canRight && (
+                    <div className="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-white to-transparent" />
+                  )}
+                  {/* Arrow nudge buttons */}
+                  {widthScale > 1 && scrollHints[d.key]?.canLeft && (
+                    <button
+                      type="button"
+                      className="absolute left-1 top-1/2 -translate-y-1/2 z-20 h-6 w-6 rounded-full bg-slate-800/70 text-white flex items-center justify-center hover:bg-slate-800"
+                      onClick={() => dayScrollRefs.get(d.key)?.scrollBy({ left: -160, behavior: 'smooth' })}
+                      aria-label="Scroll left"
+                    >
+                      <ChevronLeft className="h-4 w-4" />
+                    </button>
+                  )}
+                  {widthScale > 1 && scrollHints[d.key]?.canRight && (
+                    <button
+                      type="button"
+                      className="absolute right-1 top-1/2 -translate-y-1/2 z-20 h-6 w-6 rounded-full bg-slate-800/70 text-white flex items-center justify-center hover:bg-slate-800"
+                      onClick={() => dayScrollRefs.get(d.key)?.scrollBy({ left: 160, behavior: 'smooth' })}
+                      aria-label="Scroll right"
+                    >
+                      <ChevronRight className="h-4 w-4" />
+                    </button>
+                  )}
                 </div>
               )
             })}

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -1,8 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import MeetingBlock from './MeetingBlock.jsx'
 
 import NowMarker from './NowMarker.jsx'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
 
 
 const slotHeightPx = 48
@@ -156,20 +155,6 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
   const slots = generateTimeSlots()
   const maxVisibleColumns = useMaxVisibleColumns()
   const [expandedClumpIds, setExpandedClumpIds] = useState(new Set())
-  const dayScrollRefs = useRef({})
-  const [scrollHints, setScrollHints] = useState({})
-
-  function updateScrollHints(dayKey) {
-    const el = dayScrollRefs.current[dayKey]
-    if (!el) return
-    const canLeft = el.scrollLeft > 0
-    const canRight = el.scrollLeft + el.clientWidth < el.scrollWidth - 1
-    setScrollHints((prev) => {
-      const prevForDay = prev[dayKey] || {}
-      if (prevForDay.canLeft === canLeft && prevForDay.canRight === canRight) return prev
-      return { ...prev, [dayKey]: { canLeft, canRight } }
-    })
-  }
 
   function toggleClumpExpansion(clumpId) {
     setExpandedClumpIds((prev) => { const next = new Set(prev); if (next.has(clumpId)) next.delete(clumpId); else next.add(clumpId); return next })
@@ -303,23 +288,7 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
                     <NowMarker topPx={nowTopPx} />
                   )}
                   {/* Horizontal overflow container for overlapping meetings */}
-                  <div
-                    className="absolute inset-x-0 top-0 overflow-x-auto"
-                    style={{ height: `${gridHeightPx}px` }}
-                    ref={(el) => {
-                      if (el) {
-                        dayScrollRefs.current[d.key] = el
-                        setTimeout(() => updateScrollHints(d.key), 0)
-                      } else {
-                        delete dayScrollRefs.current[d.key]
-                        setScrollHints((prev) => {
-                          const { [d.key]: _omit, ...rest } = prev
-                          return rest
-                        })
-                      }
-                    }}
-                    onScroll={() => updateScrollHints(d.key)}
-                  >
+                  <div className="absolute inset-x-0 top-0 overflow-x-auto" style={{ height: `${gridHeightPx}px` }}>
                     <div className="relative" style={{ width: `${widthScale * 100}%`, height: `${gridHeightPx}px` }}>
                       {laidOut.map((mtg) => (
                         <MeetingBlock key={mtg.id} meeting={mtg} slotHeightPx={slotHeightPx} dayStartMinutes={startTimeMinutes} columnIndex={mtg.__layout?.columnIndex || 0} columnCount={mtg.__layout?.columnCount || 1} />
@@ -331,34 +300,6 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
                     <div className="absolute right-1.5 top-1.5 z-20">
                       <span className="text-[11px] px-1.5 py-0.5 rounded-full bg-slate-800/80 text-white">+{extraCols} more</span>
                     </div>
-                  )}
-                  {/* Scroll hint gradients */}
-                  {widthScale > 1 && scrollHints[d.key]?.canLeft && (
-                    <div className="pointer-events-none absolute inset-y-0 left-0 w-6 bg-gradient-to-r from-white to-transparent" />
-                  )}
-                  {widthScale > 1 && scrollHints[d.key]?.canRight && (
-                    <div className="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-white to-transparent" />
-                  )}
-                  {/* Arrow nudge buttons (hidden on small screens) */}
-                  {widthScale > 1 && scrollHints[d.key]?.canLeft && (
-                    <button
-                      type="button"
-                      className="hidden sm:flex absolute left-1 top-1/2 -translate-y-1/2 z-20 h-6 w-6 rounded-full bg-slate-800/70 text-white items-center justify-center hover:bg-slate-800"
-                      onClick={() => dayScrollRefs.current[d.key]?.scrollBy({ left: -160, behavior: 'smooth' })}
-                      aria-label="Scroll left"
-                    >
-                      <ChevronLeft className="h-4 w-4" />
-                    </button>
-                  )}
-                  {widthScale > 1 && scrollHints[d.key]?.canRight && (
-                    <button
-                      type="button"
-                      className="hidden sm:flex absolute right-1 top-1/2 -translate-y-1/2 z-20 h-6 w-6 rounded-full bg-slate-800/70 text-white items-center justify-center hover:bg-slate-800"
-                      onClick={() => dayScrollRefs.current[d.key]?.scrollBy({ left: 160, behavior: 'smooth' })}
-                      aria-label="Scroll right"
-                    >
-                      <ChevronRight className="h-4 w-4" />
-                    </button>
                   )}
                 </div>
               )


### PR DESCRIPTION
Enable horizontal scrolling for overlapping meetings in week and work week views to improve visibility of dense schedules.

---
<a href="https://cursor.com/background-agent?bcId=bc-a2e1e481-6b3b-4728-b098-55a8f0cd16b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a2e1e481-6b3b-4728-b098-55a8f0cd16b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

