### PR TITLE
Fix meeting time blocks

### DIFF
--- a/src/components/AddMeetingModal.jsx
+++ b/src/components/AddMeetingModal.jsx
@@ -132,7 +132,16 @@ function parseTimeToMinutes(hhmm) {
 }
 
 function formatISODate(d) {
+  // If already an ISO date string (YYYY-MM-DD), return as-is to avoid timezone shifts
+  if (typeof d === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(d)) return d
   const date = d instanceof Date ? d : new Date(d)
+  if (Number.isNaN(date.getTime())) {
+    const today = new Date()
+    const y = today.getFullYear()
+    const m = String(today.getMonth() + 1).padStart(2, '0')
+    const day = String(today.getDate()).padStart(2, '0')
+    return `${y}-${m}-${day}`
+  }
   const y = date.getFullYear()
   const m = String(date.getMonth() + 1).padStart(2, '0')
   const day = String(date.getDate()).padStart(2, '0')

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -16,8 +16,19 @@ function generateTimeSlots() {
 }
 
 function formatTimeLabel(totalMinutes) {
-  const hours24 = Math.floor(totalMinutes / 60)
-  const minutes = totalMinutes % 60
+  let total = totalMinutes
+  if (typeof totalMinutes === 'string') {
+    if (/^\d{1,2}:\d{2}$/.test(totalMinutes)) {
+      const [h, m] = totalMinutes.split(':').map((v) => parseInt(v, 10))
+      total = h * 60 + m
+    } else {
+      const num = Number(totalMinutes)
+      total = Number.isFinite(num) ? num : 0
+    }
+  }
+  if (!Number.isFinite(total)) total = 0
+  const hours24 = Math.floor(total / 60)
+  const minutes = total % 60
   const period = hours24 >= 12 ? 'PM' : 'AM'
   let hour12 = hours24 % 12
   if (hour12 === 0) hour12 = 12

--- a/src/components/MeetingBlock.jsx
+++ b/src/components/MeetingBlock.jsx
@@ -6,8 +6,27 @@ const typeToColor = {
 }
 
 export default function MeetingBlock({ meeting, slotHeightPx, dayStartMinutes, columnIndex = 0, columnCount = 1 }) {
-  const top = ((meeting.startMinutes - dayStartMinutes) / 30) * slotHeightPx
-  const height = ((meeting.endMinutes - meeting.startMinutes) / 30) * slotHeightPx
+  function toMinutes(value) {
+    if (typeof value === 'number' && Number.isFinite(value)) return value
+    if (typeof value === 'string') {
+      if (/^\d{1,2}:\d{2}$/.test(value)) {
+        const [h, m] = value.split(':').map((v) => parseInt(v, 10))
+        return h * 60 + m
+      }
+      const num = Number(value)
+      if (Number.isFinite(num)) return num
+    }
+    return NaN
+  }
+
+  const startMinRaw = toMinutes(meeting.startMinutes)
+  const endMinRaw = toMinutes(meeting.endMinutes)
+  const startMin = Number.isFinite(startMinRaw) ? startMinRaw : 0
+  let endMin = Number.isFinite(endMinRaw) ? endMinRaw : startMin + 30
+  if (endMin <= startMin) endMin = startMin + 30
+
+  const top = ((startMin - dayStartMinutes) / 30) * slotHeightPx
+  const height = ((endMin - startMin) / 30) * slotHeightPx
 
   const color = typeToColor[meeting.type] || typeToColor.Default
 
@@ -23,7 +42,7 @@ export default function MeetingBlock({ meeting, slotHeightPx, dayStartMinutes, c
       style={{ top: `${top}px`, height: `${height}px`, left: `${leftPct}%`, width: `${widthPct}%` }}
     >
       <div className="text-[11px] font-medium opacity-90">
-        {format12Hour(meeting.startMinutes)} – {format12Hour(meeting.endMinutes)}
+        {format12Hour(startMin)} – {format12Hour(endMin)}
       </div>
       <div className="text-sm font-semibold leading-tight truncate">{meeting.title}</div>
       {meeting.boardNumber && (


### PR DESCRIPTION
Adjust `formatISODate` to prevent timezone-induced day shifts for newly created meetings.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c24241a-f4de-4dd2-8dab-69e4ffc3a606">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4c24241a-f4de-4dd2-8dab-69e4ffc3a606">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

