### PR TITLE
Fix meeting display in time blocks

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -279,7 +279,7 @@ export default function Calendar({ meetings = [], view = 'workweek', currentDate
                     <NowMarker topPx={nowTopPx} />
                   )}
                   {/* Horizontal overflow container for overlapping meetings */}
-                  <div className="absolute inset-x-0 top-0 overflow-x-auto relative" style={{ height: `${gridHeightPx}px` }}>
+                  <div className="absolute inset-x-0 top-0 overflow-x-auto" style={{ height: `${gridHeightPx}px` }}>
                     <div className="relative" style={{ width: `${widthScale * 100}%`, height: `${gridHeightPx}px` }}>
                       {laidOut.map((mtg) => (
                         <MeetingBlock key={mtg.id} meeting={mtg} slotHeightPx={slotHeightPx} dayStartMinutes={startTimeMinutes} columnIndex={mtg.__layout?.columnIndex || 0} columnCount={mtg.__layout?.columnCount || 1} />


### PR DESCRIPTION
Fix incorrect meeting block positioning by removing conflicting `relative` class from overlay container.

The `relative` class on an `absolute` positioned element was preventing `top` offsets from being applied correctly, causing meetings to appear at the wrong time slots (e.g., a 9 AM meeting showing at 4:30 PM).

---
<a href="https://cursor.com/background-agent?bcId=bc-4ecc8959-66fa-4058-a50e-55a6580c7a0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ecc8959-66fa-4058-a50e-55a6580c7a0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

